### PR TITLE
fix(EventProcessor): Clean combo after triggering shortcut with Cmd

### DIFF
--- a/src/event-processor.ts
+++ b/src/event-processor.ts
@@ -43,6 +43,10 @@ export class EventProcessor {
       }
 
       this.processActionCombos(ev, actions, options)
+
+      if (this.currentCombo.stateKeys.cmd) {
+        this.cleanCombo(options)
+      }
     }
   }
 


### PR DESCRIPTION
On Mac OS, if the Cmd key is pressed during a shortcut, no keyUp event is not fired until the Cmd
key is released. For shortcuts that override default browser behavior (i.e. Cmd+F), this can result
in the default behavior being triggered if the user holds Cmd down after triggering a custom
shortcut. This fix clears the current combo after processing but before keyUp is fired, allowing
multiple Cmd-bound combos to be triggered without lifting the Cmd key between shortcuts.

Closes #20