### PR TITLE
feat(EventProcessor): Add option to reverse Action processing

### DIFF
--- a/src/event-processor.ts
+++ b/src/event-processor.ts
@@ -61,7 +61,11 @@ export class EventProcessor {
    * Search for matching actions, given a keyCombo, and execute its callbacks
    */
   public processActionCombos (ev: KeyboardEvent, actions: Map<string, Action>, options: IOptions) {
-    for (let action of actions.values()) {
+    let actionCombos = Array(...actions.values())
+    if (options.reverseActions) {
+      actionCombos.reverse()
+    }
+    for (let action of actionCombos) {
       if (this.matchesComboAction(action)) {
         if (options.debug) {
           this.printDebugActionFound(action)

--- a/src/options.ts
+++ b/src/options.ts
@@ -2,6 +2,7 @@ export interface IOptions {
   debug?: boolean
   preventDefault?: boolean
   onlyStateCombos?: boolean
+  reverseActions?: boolean
 }
 
 // Options class
@@ -20,6 +21,11 @@ export class Options implements IOptions {
    * Only process combos with State keys (cmd, ctrl, alt, shift)
    */
   public onlyStateCombos: boolean = false
+
+  /**
+   * Process combos in LIFO order
+   */
+  public reverseActions: boolean = false
 
   constructor(obj?: IOptions) {
     if (obj && Object.keys(obj).some(key => typeof this[key] === 'undefined')) {

--- a/test/event-processor.test.ts
+++ b/test/event-processor.test.ts
@@ -28,14 +28,22 @@ describe('EventProcessor', () => {
   let actions: Map<string, Action>
   let cb = jest.fn()
   let cb2 = jest.fn()
+  let cb3 = jest.fn()
+  let cb4 = jest.fn()
 
   beforeEach(() => {
     eventProcessor = new EventProcessor()
     actions = new Map()
     const action = new Action('action', KeyCombo.fromString('ctrl a'))
+    const newaction = new Action('newaction', KeyCombo.fromString('ctrl b'))
+    const othernewaction = new Action('othernewaction', KeyCombo.fromString('ctrl b'))
     action.addCallback(cb)
     action.addCallback(cb2)
+    newaction.addCallback(cb3)
+    othernewaction.addCallback(cb4)
     actions.set('action', action)
+    actions.set('newaction', newaction)
+    actions.set('othernewaction', othernewaction)
   })
 
   afterEach(() => {
@@ -130,6 +138,20 @@ describe('EventProcessor', () => {
       const ev = getMockedEvent(65, { ctrlKey: true } as any)
       eventProcessor.processEvent(ev, actions, opt) // a
       expect(ev.preventDefault).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls the oldest callback per shortcut', () => {
+      const opt = new Options()
+      eventProcessor.processEvent(getMockedEvent(17, { ctrlKey: true } as any), actions, opt) // ctrl
+      eventProcessor.processEvent(getMockedEvent(66, { ctrlKey: true } as any), actions, opt) // b
+      expect(cb3).toBeCalled()
+    })
+
+    it('calls the newest callback per shortcut if reverseActions option is passed', () => {
+      const opt = new Options({ reverseActions: true })
+      eventProcessor.processEvent(getMockedEvent(17, { ctrlKey: true } as any), actions, opt) // ctrl
+      eventProcessor.processEvent(getMockedEvent(66, { ctrlKey: true } as any), actions, opt) // b
+      expect(cb4).toBeCalled()
     })
   })
 })

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -2,7 +2,12 @@ import { Options, IOptions } from '../src/options'
 
 describe('Options', () => {
   it('has expected defaults if no params are passed', () => {
-    expect(new Options()).toEqual({ debug: false, preventDefault: false, onlyStateCombos: false })
+    expect(new Options()).toEqual({
+      debug: false,
+      preventDefault: false,
+      onlyStateCombos: false,
+      reverseActions: false
+    })
   })
 
   it('merges options when valid options are passed', () => {


### PR DESCRIPTION
Adds an option to process Actions per KeyCombo in LIFO order, calling the newest Action's callbacks first.

Closes #22